### PR TITLE
fix two_player_gan _emb and script

### DIFF
--- a/models/two_player_gan_model.py
+++ b/models/two_player_gan_model.py
@@ -79,7 +79,7 @@ class TwoPlayerGANModel(BaseModel):
         self.loss_G_fake, self.loss_G_real = self.criterionG(fake_out, real_out)
         if self.opt.dataset_mode == 'embedding':
             embedding_dim = gen_data['data'].shape[1]
-            self.loss_G_orthogonal = torch.norm(self.netG.module.layer.weight.data - torch.eye(embedding_dim)) * 0.001
+            self.loss_G_orthogonal = torch.norm(self.netG.module.layer.weight.data - torch.eye(embedding_dim).cuda()) * 0.001
         else:
             self.loss_G_orthogonal = 0.
         self.loss_G = self.loss_G_fake + self.loss_G_real + self.loss_G_orthogonal

--- a/scripts/train_egan_emb.sh
+++ b/scripts/train_egan_emb.sh
@@ -2,14 +2,14 @@ source_dataset_name=$1
 target_dataset_name=$2
 
 set -ex
-python train.py --name lsgan_emb \
+python train.py --name egan_emb \
        --dataset_mode embedding --batch_size 32 --dataroot None \
        --max_dataset_size 200000 --preprocess center \
        --source_dataset_name $source_dataset_name --target_dataset_name $target_dataset_name \
        --model egan --gan_mode unconditional \
        --gpu_ids 0 \
        --d_loss_mode vanilla --g_loss_mode nsgan vanilla lsgan --which_D S \
-       --lr_g 0.1 --lr_d 0.1 --beta1 0.5 --beta2 0.9 \
+       --optim_type SGD --lr_g 0.1 --lr_d 0.1 \
        --netD fc --netG fc --ngf 128 --ndf 128 --g_norm none --d_norm none \
        --init_type diagonal --init_gain 0.02 \
        --no_dropout --no_flip \

--- a/scripts/train_two_player_emb.sh
+++ b/scripts/train_two_player_emb.sh
@@ -17,3 +17,6 @@ python train.py --name lsgan_emb \
        --score_name muse-csls-en \
        --print_freq 2000 --display_freq 2000 --score_freq 10000 \
        --save_latest_freq 100000 --save_giters_freq 100000 --most_frequent 75000
+       # good hyper param for wgan
+       # --d_loss_mode wgan --g_loss_mode wgan --which_D S --use_gp \
+       # --optim_type Adam --lr_g 0.001 --lr_d 0.001 \ 


### PR DESCRIPTION
1. a small bug fixed
2. add wgan param for future experiments. Currently wgan can align fasttext cbow with skipgram but egan can't. However, for aligning skipgram0to0.1 and 0.1to0.2 egan, seems to align them in fewer iterations.